### PR TITLE
remapping of COCs in import file when scheme is not UID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datimvalidation
 Type: Package
 Title: External Validation Routines for Data Payloads in DATIM
-Version: 1.3.1
-Date: 2022-09-23
+Version: 1.3.2
+Date: 2022-10-25
 Authors@R: c(
     person("Jason", "Pickering", email = "jason.p.pickering@gmail.com",
         role = c("aut", "cre")),

--- a/R/d2Parser.R
+++ b/R/d2Parser.R
@@ -283,6 +283,14 @@ d2Parser <-
           d2session = d2session
         )
       }
+      if (idScheme != "id") {
+        data$categoryOptionCombo <- remapCategoryOptionCombos(
+          data$categoryOptionCombo,
+          mode_in = idScheme,
+          mode_out = "id",
+          d2session = d2session
+        )
+      }
 
       #Data frame needs to be completely flattened to characters
       data <- plyr::colwise(as.character)(data)

--- a/R/getCategoryOptionCombosMap.R
+++ b/R/getCategoryOptionCombosMap.R
@@ -16,7 +16,7 @@ getCategoryOptionCombosMap <- function(d2session = dynGet("d2_default_session",
 
   url <- utils::URLencode(
     paste0(d2session$base_url, "api/", api_version(),
-           "/categoryOptionCombos?fields=id,name,shortName,code&paging=false"))
+           "/categoryOptionCombos?filter=categoryCombo.id:neq:wUpfppgjEza&fields=id,name,shortName,code&paging=false"))
   r <- httpcache::GET(url,
                httr::timeout(300),
                handle = d2session$handle)

--- a/R/getCategoryOptionCombosMap.R
+++ b/R/getCategoryOptionCombosMap.R
@@ -16,7 +16,7 @@ getCategoryOptionCombosMap <- function(d2session = dynGet("d2_default_session",
 
   url <- utils::URLencode(
     paste0(d2session$base_url, "api/", api_version(),
-           "/categoryOptionCombos?filter=categoryCombo.id:neq:wUpfppgjEza&fields=id,name,shortName,code&paging=false"))
+           "/categoryOptionCombos?fields=id,name,shortName,code&paging=false"))
   r <- httpcache::GET(url,
                httr::timeout(300),
                handle = d2session$handle)


### PR DESCRIPTION
I updated d2parser to add remapping of provided COCs if scheme is not UID. I also update the getCategoryOptionCombosMap to exclude mechanisms from the result.